### PR TITLE
feat:cloud pub/sub 기능 구현

### DIFF
--- a/src/cloud-pubsub-bus.spec.ts
+++ b/src/cloud-pubsub-bus.spec.ts
@@ -1,0 +1,90 @@
+import { PubSub } from '@google-cloud/pubsub';
+import { CloudPubSubBus } from './';
+
+describe('CloudPubSubBus', () => {
+  const SECOND_TO_MILS = 1_000;
+  jest.setTimeout(SECOND_TO_MILS * 10);
+
+  let bus;
+  let client;
+  const projectId = 'project-test';
+  const topic = 'busTest';
+  const topicPrefix = 'topic-';
+  const subscriptionPrefix = 'sub-';
+  const topicName = topicPrefix + topic;
+  const subscriptionName = subscriptionPrefix + topic;
+  const TEST_DELAY = 500;
+  const clientConfig = { apiEndpoint: 'localhost:8085', projectId, keyFilename: '/file-path/key.json' };
+
+  beforeAll(async () => {
+    client = new PubSub(clientConfig);
+    await client.createTopic(topicName);
+    await client.createSubscription(topicName, subscriptionName);
+  });
+
+  beforeEach((done) => {
+    bus = CloudPubSubBus.create({ topicPrefix, subscriptionPrefix, clientConfig });
+    done();
+  });
+
+  afterEach((done) => {
+    bus.destroy();
+    setTimeout(done, TEST_DELAY);
+  });
+
+  afterAll(() => {
+    client.topic(topicName).delete();
+    client.subscription(subscriptionName).delete();
+    client.close();
+    bus.destroy();
+  });
+
+  describe('publish/subscribe', () => {
+    test('should forward messages to only one receiver', (done) => {
+      const acc: unknown[] = [];
+      bus.subscribe(topic, (message: string) => {
+        acc.push(message);
+      });
+      const acc2: unknown[] = [];
+      bus.subscribe(topic, (message: string) => {
+        acc2.push(message);
+      });
+      bus.publish(topic, 'foo');
+      bus.publish(topic, 'bar');
+      bus.publish(topic, 'baz');
+      bus.publish(topic, 'qux');
+      setTimeout(() => {
+        expect(acc.sort()).toEqual(['bar', 'baz', 'foo', 'qux']);
+        expect(acc2).toEqual([]);
+        done();
+      }, TEST_DELAY);
+    });
+
+    test('should not forward messages after unreceive', (done) => {
+      const acc: unknown[] = [];
+      const listener1 = (message: string) => {
+        acc.push(message);
+      };
+      bus.subscribe(topic, listener1);
+      const acc2: unknown[] = [];
+      const listener2 = (message: string) => {
+        acc2.push(message);
+      };
+      bus.subscribe(topic, listener2);
+      bus.publish(topic, 'foo');
+      bus.publish(topic, 'bar');
+      setTimeout(() => {
+        bus.unsubscribe(topic, listener1);
+        setTimeout(() => {
+          bus.publish(topic, 'baz');
+          bus.publish(topic, 'qux');
+          setTimeout(() => {
+            expect(acc.sort()).toEqual(['bar', 'foo']);
+            expect(acc2.sort()).toEqual(['baz', 'qux']);
+            done();
+          }, TEST_DELAY);
+        }, TEST_DELAY);
+      }, TEST_DELAY);
+    });
+  });
+});

--- a/src/cloud-pubsub-bus.ts
+++ b/src/cloud-pubsub-bus.ts
@@ -1,43 +1,120 @@
 import Debug from 'debug';
-import { PubSub, ClientConfig } from '@google-cloud/pubsub';
+import { PubSub, ClientConfig, Subscription, Message } from '@google-cloud/pubsub';
+import { EventEmitter } from 'events';
 import { BaseBus, FastBusOpts, FastBusSubscriber } from './fast-bus.interface';
 const debug = Debug('fastbus');
 
 interface CloudPubsubBusOpts extends FastBusOpts {
-  ClientConfig: ClientConfig;
+  clientConfig: ClientConfig;
+  topicPrefix?: string;
+  subscriptionPrefix?: string;
 }
 
 export class CloudPubSubBus implements BaseBus {
-  prefix?: string;
+  busType: string;
+  topicPrefix?: string;
+  subscriptionPrefix?: string;
   pubsub: PubSub;
+  subscribeClients: Record<string, Subscription>;
+  subscriptions: EventEmitter;
 
   constructor(opts?: CloudPubsubBusOpts) {
-    this.pubsub = new PubSub(opts?.ClientConfig);
-    this.prefix = opts?.prefix;
+    this.pubsub = new PubSub(opts?.clientConfig);
+    this.busType = 'CloudPubSub';
+    this.topicPrefix = opts?.topicPrefix || '';
+    this.subscriptionPrefix = opts?.subscriptionPrefix || '';
+    this.subscribeClients = {};
+
+    this.subscriptions = new EventEmitter();
+    this.subscriptions.setMaxListeners(Infinity);
   }
 
   publish(topic: string, message: string, broadcast: boolean = false) {
     if (broadcast) {
-      debug('**warning** broadcast is not implemented!');
+      debug('broadcast is not implemented!');
       return;
     }
-    // to implement
+    const dataBuffer = Buffer.from(message);
+    const topicName = this.toTopicName(topic);
+    this.pubsub
+      .topic(topicName)
+      .publish(dataBuffer)
+      .then((messageId) => {
+        debug(`Message ${messageId} published`);
+      })
+      .catch((err) => {
+        debug('**warning** publish error!', topicName, message, JSON.stringify(err));
+      });
   }
 
   subscribe(topic: string, listener: FastBusSubscriber) {
-    // to implement
+    const subscriptionName = this.toSubscriptionName(topic);
+    this.subscriptions.on(subscriptionName, listener);
+    this.onSubscription(subscriptionName);
   }
 
   unsubscribe(topic: string, listener: FastBusSubscriber) {
-    // to implement
+    this.subscriptions.off(this.toSubscriptionName(topic), listener);
   }
 
   unsubscribeAll(topic?: string) {
-    // to implement
+    if (topic) {
+      const subscriptionName = this.toSubscriptionName(topic);
+      this.subscriptions.removeAllListeners(subscriptionName);
+      this.getSubscribeClient(subscriptionName).removeAllListeners();
+    } else {
+      this.subscriptions.removeAllListeners();
+      for (const subscriptionName in this.subscribeClients) {
+        this.getSubscribeClient(subscriptionName).removeAllListeners();
+      }
+    }
+  }
+
+  private onSubscription(subscriptionName: string) {
+    let subscribeClient = this.getSubscribeClient(subscriptionName);
+    if (!subscribeClient) {
+      this.subscribeClients[subscriptionName] = this.pubsub.subscription(subscriptionName);
+      subscribeClient = this.getSubscribeClient(subscriptionName);
+    }
+
+    if (subscribeClient.listenerCount('message') === 0) {
+      subscribeClient
+        .on('message', (message: Message) => {
+          if (this.subscriptions.listenerCount(subscriptionName) === 0) {
+            this.getSubscribeClient(subscriptionName).removeAllListeners();
+            message.nack();
+            return;
+          }
+          debug(`Received message: id ${message.id}, data ${message.data}`);
+          message.ack();
+          const listener = this.subscriptions.listeners(subscriptionName)[0];
+          listener(message.data.toString());
+        })
+        .on('error', (err) => {
+          debug('**warning** subscribe error!', JSON.stringify(err));
+        });
+    }
+
+    if (!subscribeClient.isOpen) {
+      subscribeClient.open();
+    }
+  }
+
+  private toTopicName(topic: string) {
+    return this.topicPrefix + topic;
+  }
+
+  private toSubscriptionName(topic: string) {
+    return this.subscriptionPrefix + topic;
+  }
+
+  private getSubscribeClient(subscriptionName) {
+    return this.subscribeClients[subscriptionName];
   }
 
   destroy() {
     this.unsubscribeAll();
+    this.pubsub.close();
   }
 
   static create(opts?: CloudPubsubBusOpts): CloudPubSubBus {

--- a/src/redis-bus.ts
+++ b/src/redis-bus.ts
@@ -12,6 +12,7 @@ interface RedisBusOpts extends FastBusOpts {
   createRedisClient?: (RedisOptions?) => Redis;
 }
 export class RedisBus implements BaseBus {
+  busType: string;
   prefix: string;
   subscriptions: EventEmitter;
   pubClient: Redis;
@@ -22,6 +23,7 @@ export class RedisBus implements BaseBus {
     this.subClient = opts?.createRedisClient ? opts?.createRedisClient(opts?.redis) : new IORedis(opts?.redis);
     debug(`connect redis: ${opts?.redis?.host}:${opts?.redis?.port}/${opts?.redis?.db}`);
 
+    this.busType = 'Redis';
     this.prefix = `${opts?.prefix ?? 'bus'}:${opts?.redis?.db ?? '0'}:`;
 
     this.subscriptions = new EventEmitter();
@@ -58,7 +60,6 @@ export class RedisBus implements BaseBus {
   }
 
   destroy() {
-    debug('destroy');
     this.unsubscribeAll();
     this.subClient.disconnect();
     this.pubClient.disconnect();


### PR DESCRIPTION
## 개요

**목적** 
Cloud Pub/Sub Client를 구현합니다.

**설명**
문서: https://cloud.google.com/pubsub/docs

## 메시지 수신 방식

**우리 내부에서 사용하고 있는 Pub/Sub의 용도에 따른 메시지 수신 방식**
* deimos trigger 용: [푸시 방식](https://cloud.google.com/pubsub/docs/push)
* 개별 메시지 전송용: [pull 방식](https://cloud.google.com/pubsub/docs/pull)

## Cloud Pub/Sub VS Redis Pub/Sub

<img width="809" alt="Screen Shot 2022-01-28 at 17 59 29" src="https://user-images.githubusercontent.com/47456161/151517471-45cdf180-80ee-4720-bc08-b8f21b21ec75.png">

Redis는 topic과 channel 관리 없이 사용할 수 있지만 Cloud Pub/Sub은 조금 다릅니다. 
주제(topic)와, 구독(subscription)을 따로 관리해주어야 합니다. 
주제를 등록하고 메시지를 소비하는 **구독**을 설정해주게 되면, 주제로 publish된 메시지가 등록된 구독으로 전달됩니다.

위 그림 처럼 하나의 **주제**에 하나의 구독과 여러개의 주제를 등록할 수 있습니다. (일대다)


### message ack와 nack를 활용해서 하나의 subscribe에만 메시지 전송 보장하기

```typescript
private init(opts: CloudPubsubBusOpts) {
// ...
    this.subscriptions = new EventEmitter();
    this.subscriptions.setMaxListeners(Infinity);
}
// ...
subscription
        .on('message', (message: Message) => {
          if (this.subscriptions.listenerCount(subscriptionName) === 0) { // 1
           subscribeClient.removeAllListeners(); // 2
            message.nack(); // 3
            return;
          }
          debug(`Received message: id ${message.id}, data ${message.data}`);
          message.ack();
          const listener = this.subscriptions.listeners(subscriptionName)[0];
          listener(message.data.toString());
        })
        .on('error', (err) => {
          debug('**ignore** subscribe error!', JSON.stringify(err));
        });
     ...
    }
  }
```


<img width="653" alt="Screen Shot 2022-01-28 at 17 59 37" src="https://user-images.githubusercontent.com/47456161/151517488-291e52d6-12f4-4c06-bf4b-50f86d352538.png">
 
message를 수신하고 message.ack 함수가 호출되면, cloud pub/sub subscription에 저장된 메시지가 사라지게 됩니다.
그리고 message.nack를 호출하면 메시지를 처리하지 않은 상태로 cloud pub/sub으로 보내고 다시 전송하게 됩니다.

Redis Pub/Sub에서 개별 메시지 전송은 lpush, rpop을 활용해 단 하나의 `subscribe`에게 전송되는것을 보장한 것처럼, 
Cloud pub/sub도 같은 동작을 하도록 했습니다. 

위 코드를 보면, this.subscriptions은 EventEmitter의 인스턴스입니다.

1. EventEmitter에 특정 구독이름(subscriptionName)으로 등록된 이벤트가 없으면, 구독을 할 수 없는 상태로 간주합니다.
2. 해당 cloud pub/sub 구독 인스턴스에 존재하는 listener를 모두 제거합니다. (`message`와 `error`에 등록된 함수) 해당 함수가 실행되면서 구독은 더 이상 메시지를 받을 수 없는, close 상태가 됩니다.
3. message.nack 함수를 호출하게 되면, 해당 메시지가 cloud pub/sub에서 재전송 됩니다. 메시지를 다른 listener가 소비할 수 없는 상황이라면 cloud pub/sub 저장소에 7일간 저장됩니다.

## 테스트
테스트 코드는 local emulator에서 동작하게 됩니다.
다음 작업에서 github action으로 emulator를 올리거나, mock 처리로 변경하고자 합니다.

#### 작업 리스트
- [x] init PR, 구조 init
- [x] Cloud Pub/Sub Client 구현
- [x] Topic,Subscription 이름 변환 함수 추가 (논의 필요)
- [x] Cloud Pub/Sub test code 추가 ([Cloud Pub/Sub emulator](https://cloud.google.com/pubsub/docs/emulator)를 github action에 추가할 수 있는지 확인 필요)
