### PR TITLE
Feat/ci cloud pubsub emulator

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           node-version: '16'
           cache: 'npm'
+      - name: 'Install Cloud SDK'
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          install_components: 'beta,pubsub-emulator'
       - name: Prepare dot npmrc for private registry
         run: echo //npm.pkg.github.com/:_authToken=${{ secrets.NPM_TOKEN }} >> ~/.npmrc
       - name: Bootstrap
@@ -30,8 +34,12 @@ jobs:
         env:
           NODE_ENV: dev
           CI: true
+      - name: 'Start Pub/Sub emulator'
+        run: |
+          gcloud beta emulators pubsub start --project=project-test --host-port=0.0.0.0:8085 &
       - name: Test
         run: npm run test
         env:
           NODE_ENV: test
+          PUBSUB_EMULATOR_HOST: 'localhost:8085'
           CI: true


### PR DESCRIPTION
## 개요

https://github.com/day1co/fastbus/pull/2 PR과 이어지는 내용입니다.

* Cloud Pub/Sub 테스트를 위해 github workflows에 emulator 설치 step을 추가합니다.

## 변경 사항
1. ci test node version [16.x]로 변경
2. github workflows에 emulator 설치 step을 추가
